### PR TITLE
Add MIT license and community guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: "Reporte de bug"
+description: "Crear un reporte de error"
+title: "[BUG] Título descriptivo"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por tomar el tiempo de reportar un problema.
+  - type: input
+    id: resumen
+    attributes:
+      label: Resumen
+      description: Describe el bug brevemente.
+    validations:
+      required: true
+  - type: textarea
+    id: pasos
+    attributes:
+      label: Pasos para reproducir
+      description: Lista los pasos necesarios para reproducir el problema.
+    validations:
+      required: true
+  - type: textarea
+    id: comportamiento
+    attributes:
+      label: Comportamiento esperado
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto adicional
+      description: Información extra como logs o capturas.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: "Solicitud de mejora"
+description: "Proponer una nueva funcionalidad"
+title: "[FEATURE] Título descriptivo"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por proponer una idea.
+  - type: input
+    id: resumen
+    attributes:
+      label: Resumen
+      description: Describe brevemente la mejora propuesta.
+    validations:
+      required: true
+  - type: textarea
+    id: motivacion
+    attributes:
+      label: Motivación
+      description: ¿Qué problema resuelve?
+    validations:
+      required: true
+  - type: textarea
+    id: detalles
+    attributes:
+      label: Detalles adicionales
+      description: Información extra o contexto.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Resumen
+- 
+
+## Pruebas
+- [ ] `npm test`
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+
+## Notas
+- 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Código de Conducta del Convenio de Contribuyentes
+
+## Nuestro compromiso
+Nos comprometemos a crear un ambiente abierto y acogedor, sin acoso para cualquier persona, independientemente de su edad, dimensión corporal, discapacidad visible u oculta, etnia, características sexuales, identidad y expresión de género, nivel de experiencia, educación, estatus socioeconómico, nacionalidad, apariencia personal, raza, religión o identidad y orientación sexual.
+
+## Nuestros estándares
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo:
+- Demostrar empatía y amabilidad hacia otras personas.
+- Respetar diferentes opiniones, puntos de vista y experiencias.
+- Aceptar con gracia críticas constructivas.
+- Enfocarse en lo que es mejor para la comunidad.
+- Mostrar empatía hacia otros miembros de la comunidad.
+
+Ejemplos de comportamiento inaceptable:
+- Uso de lenguaje o imágenes sexualizadas y atención sexual no deseada.
+- Trolling, comentarios insultantes o despectivos, y ataques personales o políticos.
+- Acoso público o privado.
+- Publicación de información privada de otras personas sin su consentimiento.
+- Otras conductas que puedan considerarse inapropiadas en un entorno profesional.
+
+## Responsabilidades de la comunidad
+Los líderes de la comunidad son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán acciones correctivas apropiadas y justas en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo o dañino.
+
+## Alcance
+Este Código de Conducta se aplica dentro de todos los espacios del proyecto y también se aplica cuando una persona representa oficialmente al proyecto en espacios públicos.
+
+## Aplicación
+Los casos de comportamiento abusivo, acosador o inaceptable pueden ser reportados mediante el correo `security@example.com`. Todas las denuncias serán revisadas e investigadas y resultarán en una respuesta que se considere necesaria y apropiada a las circunstancias.
+
+## Atribución
+Este Código de Conducta es una adaptación de la versión 2.1 del [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Guía de contribución
+
+Gracias por tu interés en mejorar el proyecto. Para mantener la calidad del código sigue estas recomendaciones:
+
+## Ramas
+- La rama principal es `main`.
+- Crea ramas de trabajo a partir de `main` usando el formato `feature/nombre-descriptivo` o `fix/nombre-descriptivo`.
+
+## Convención de commits
+- Utiliza [Conventional Commits](https://www.conventionalcommits.org/) en inglés.
+- Ejemplos: `feat: add nueva plantilla`, `fix: corregir validación`.
+
+## Requisitos de pruebas
+Antes de enviar un pull request ejecuta localmente:
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+```
+
+Asegúrate de que todos los comandos finalicen sin errores.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 BRIK Project Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Política de seguridad
+
+Agradecemos los reportes de vulnerabilidades. Para informar cualquier problema de seguridad:
+- Envía un correo a `security@example.com`.
+- También puedes usar la función de [GitHub Security Advisories](https://github.com/security-advisories/new).
+
+## Versiones soportadas
+Solo la rama `main` recibe soporte y correcciones de seguridad activas. Se recomienda actualizar siempre a la última versión disponible.


### PR DESCRIPTION
## Summary
- add MIT License
- document contributing process and code of conduct
- include security policy, issue templates, and PR template

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*
- `npm run typecheck` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2b86b8e0c832683b7a4cdf70bf094